### PR TITLE
Add a basic devcontainer to support codespaces workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,11 @@
+{
+  "build": {
+    "dockerfile": "../Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": ["rust-lang.rust-analyzer"]
+    }
+  },
+  "forwardPorts": [3928]
+}


### PR DESCRIPTION
This allows anyone with vscode or a browser (or a devcontainer setup) to run `/usr/bin/union_bug` and have a working instance exposed on any machine.

It **_does not_** create a working development environment. I think it would need a separate `Dockerfile` and I'm only moderately ok with those so it might take me some time and I'm going to need to find some energy to see this through.

It also adds the `rust-analyzer` extension to the codespace for people who don't have dotfiles configured. I don't speak rust but it seemed pretty popular. If there are other extensions worth adding, we can keep adding.

If you try this out, I recommend selecting an 8-core machine. You can get a working instance in minutes. If we do go down this road, and move the repo to an organization, we can turn on "prebuilds" such that a working dev environment can be spun up in seconds.