### PR TITLE
Devcontainer improvements

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,11 +1,18 @@
 {
   "build": {
-    "dockerfile": "../Dockerfile"
+    "dockerfile": "../Dockerfile.devcontainer"
   },
   "customizations": {
     "vscode": {
-      "extensions": ["rust-lang.rust-analyzer"]
+      "extensions": [
+        "rust-lang.rust-analyzer",
+        "arcanis.vscode-zipfs",
+        "dabeumer.vscode-eslint",
+        "vadimcn.vscode-lldb",
+        "esbenp.prettier-vscode"
+      ]
     }
   },
-  "forwardPorts": [3928]
+  "forwardPorts": [3928],
+  "postCreateCommand": "yarn install"
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,14 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Run webpack-dev-server",
+      "runtimeExecutable": "yarn",
+      "runtimeArgs": ["run", "start"],
+      "console": "integratedTerminal"
+    },
+    {
       "type": "lldb",
       "request": "launch",
       "name": "Debug executable 'union_bug'",
@@ -20,7 +28,8 @@
         "RUST_LOG": "debug",
         "WEBPACK_DEV_SERVER": "1"
       },
-      "cwd": "${workspaceFolder}"
+      "cwd": "${workspaceFolder}",
+      "initCommands": ["settings set target.disable-aslr false"]
     },
     {
       "type": "lldb",
@@ -35,6 +44,15 @@
       },
       "args": [],
       "cwd": "${workspaceFolder}"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Client/Server",
+      "configurations": [
+        "Run webpack-dev-server",
+        "Debug executable 'union_bug'"
+      ]
     }
   ]
 }

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,0 +1,8 @@
+FROM debian:bookworm
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends curl ca-certificates libdav1d-dev libclang-dev build-essential pkg-config git
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
+  apt-get install -y nodejs &&\
+  corepack enable

--- a/Dockerfile.devcontainer
+++ b/Dockerfile.devcontainer
@@ -1,7 +1,7 @@
 FROM debian:bookworm
 
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends curl ca-certificates libdav1d-dev libclang-dev build-essential pkg-config git
+  apt-get install -y --no-install-recommends curl ca-certificates libdav1d-dev libclang-dev build-essential pkg-config git openssh-client
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
   apt-get install -y nodejs &&\


### PR DESCRIPTION
This sets up a separate Dockerfile for running a devcontainer in vscode and Codespaces.  It also adds a compound launch configuration for running webpack-dev-server and the server app simultaneously.